### PR TITLE
Page type edition

### DIFF
--- a/docs/creating_forms.md
+++ b/docs/creating_forms.md
@@ -1,8 +1,9 @@
 ---
 description: Use surveys, questionnaires, sign-up forms and other interactive forms to enrich your site.
+edition: experience
 ---
 
-# Creating forms [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
+# Creating forms
 
 With forms you can place a survey, questionnaire, sign-up form, etc. on your website.
 

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -510,6 +510,10 @@ a.external:after {
   border-bottom: 2px solid var(--ibexa-dusk-black);
 }
 
+div.pills {
+    float: right;
+}
+
 .pill {
     background-color: var(--ibexa-jazzberry);
     border-radius: 2.18px;

--- a/docs/personalization/integrating_results.md
+++ b/docs/personalization/integrating_results.md
@@ -1,8 +1,9 @@
 ---
 description: You can display recommendation results in your Pages by using the Personalized block.
+edition: experience
 ---
 
-# Integrate scenario results [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
+# Integrate scenario results
 
 When the Personalization service is [enabled](enabling_personalization.md) and properly 
 [configured](perso_configuration.md), as an editor, you can embed the recommendations 

--- a/docs/shop_administration/customer_portal.md
+++ b/docs/shop_administration/customer_portal.md
@@ -1,8 +1,9 @@
 ---
 description: Customer Portal allows your clients to create and manage business account for their company.
+edition: experience
 ---
 
-# Customer Portal account [[% include 'snippets/experience_badge.md' %]]
+# Customer Portal account
 
 Customer Portal allows you to create and manage your business account.
 With this feature, you can edit your organization information,

--- a/docs/shop_administration/manage_orders.md
+++ b/docs/shop_administration/manage_orders.md
@@ -1,8 +1,9 @@
 ---
 description: You can view a list of placed orders and their details in the Back Office.
+edition: commerce
 ---
 
-# Orders [[% include 'snippets/commerce_badge.md' %]]
+# Orders
 
 [[= product_name =]] provides a list of all orders in **eCommerce** > **Order Management**.
 

--- a/docs/shop_administration/manage_users.md
+++ b/docs/shop_administration/manage_users.md
@@ -1,8 +1,9 @@
 ---
 description: You can manage and view customers and organizations' accounts in your system, including their shop activities such as orders.
+edition: experience
 ---
 
-# Customer management [[% include 'snippets/experience_badge.md' %]]
+# Customer management
 
 In the Back Office, you can manage members of your team,
 customers and organizations' accounts in your system, including their shop activities such as orders.

--- a/docs/shop_administration/shop_administration.md
+++ b/docs/shop_administration/shop_administration.md
@@ -1,8 +1,9 @@
 ---
 description: Manage the most important shop data and settings in the Back Office.
+edition: commerce
 ---
 
-# Shop administration [[% include 'snippets/commerce_badge.md' %]]
+# Shop administration
 
 [[= product_name =]] provides the following eCommerce functions in the left menu of the Back Office.
 

--- a/docs/shop_administration/shop_dashboard.md
+++ b/docs/shop_administration/shop_dashboard.md
@@ -1,8 +1,9 @@
 ---
 description: The Dashboard contains an overview and statistical information about your shop.
+edition: commerce
 ---
 
-# Dashboard [[% include 'snippets/commerce_badge.md' %]]
+# Dashboard
 
 The Dashboard shows the most important information for the shop owner referring to the installation.
 

--- a/docs/site_organization/site_factory.md
+++ b/docs/site_organization/site_factory.md
@@ -1,8 +1,9 @@
 ---
 description: Use Site Factory to easily create multiple sites, with different designs and subsets of content, based on common skeletons.
+edition: experience
 ---
 
-# Site Factory [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
+# Site Factory
 
 The Site Factory enables you to easily create and manage multiple sites in different languages from one place.
 All the sites can be kept in the Repository of your installation.

--- a/docs/site_organization/working_with_page.md
+++ b/docs/site_organization/working_with_page.md
@@ -1,8 +1,9 @@
 ---
 description: In Ibexa DXP you can create multi-zone Pages with dynamic blocks to use as landing pages.
+edition: experience
 ---
 
-# Pages [[% include 'snippets/experience_badge.md' %]] [[% include 'snippets/commerce_badge.md' %]]
+# Pages
 
 **Page** is a special Content Type that contains zones onto which you can drop 
 different dynamic blocks.

--- a/theme/main.html
+++ b/theme/main.html
@@ -53,11 +53,15 @@
               {% endfor %}
                   <li class="breadcrumb-item breadcrumb-item-current">{{ page.title }}</li>
           </ul>
-          {% if page.meta.edition == 'commerce' %}
-            <span class="pill commerce-pill"></span>
-          {% elif page.meta.edition == 'experience' %}
-            <span class="pill experience-pill"></span>
-            <span class="pill commerce-pill"></span>
+          {% if page.meta.edition %}
+            <div class="pills">
+            {% if page.meta.edition == 'commerce' %}
+                <span class="pill commerce-pill"></span>
+            {% elif page.meta.edition == 'experience' %}
+                <span class="pill experience-pill"></span>
+                <span class="pill commerce-pill"></span>
+            {% endif %}
+            </div>
           {% endif %}
           {{ page.content }}
           {% include "partials/tags.html" %}

--- a/theme/main.html
+++ b/theme/main.html
@@ -53,6 +53,12 @@
               {% endfor %}
                   <li class="breadcrumb-item breadcrumb-item-current">{{ page.title }}</li>
           </ul>
+          {% if page.meta.edition == 'commerce' %}
+            <span class="pill commerce-pill"></span>
+          {% elif page.meta.edition == 'experience' %}
+            <span class="pill experience-pill"></span>
+            <span class="pill commerce-pill"></span>
+          {% endif %}
           {{ page.content }}
           {% include "partials/tags.html" %}
         </div>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | n/a
| Versions      | all

Test for adding edition/flavor information using metadata instead of manually linking to edition badges.

Badges would still be in use for in page sections (optionally: use styling of individual html elements?)

#### Checklist

- [x] Text renders correctly
- [x] Remove REMOVE commit
- [x] Fix styling (margins)
