### PR TITLE
Add inline image styling

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -456,6 +456,11 @@ a.external:not(.card):after {
     cursor: pointer;
 }
 
+.md-content img.inline-image {
+    display: inline;
+    max-height: 1rem;
+}
+
 /* UI guidelines */
 
 .ez-code-example {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | n/a
| Versions      | all + copy to developer-doc

Adds styling for inline images, as introduced in https://github.com/ibexa/documentation-connect/blob/main/docs/css/custom.css#L652-L655. To be used for buttons, icons, etc.

To mark an image as inline, add `{.inline-image}` after the link (without a space):

`![Image alt](image-name.png){.inline-image}`

This does not work for images that have a caption.
