### PR TITLE
cards: force_version="4.5"

### DIFF
--- a/docs/commerce/commerce.md
+++ b/docs/commerce/commerce.md
@@ -28,4 +28,4 @@ Once the order is placed, users can interact with it by working with the followi
     "commerce/order_management/order_management",
     "commerce/payment/payment_management",
     "commerce/shipping_management/shipping_management"
-], columns=3) =]] 
+], columns=3, force_version="4.5") =]] 

--- a/docs/commerce/order_management/order_management.md
+++ b/docs/commerce/order_management/order_management.md
@@ -20,4 +20,4 @@ The Order management package interacts with other packages of the system, so tha
 
 [[= cards([
     "commerce/order_management/work_with_orders"
-], columns=3) =]] 
+], columns=3, force_version="4.5") =]] 

--- a/docs/commerce/payment/payment_management.md
+++ b/docs/commerce/payment/payment_management.md
@@ -19,4 +19,4 @@ The Payment management module interacts with other packages of the system, so th
 [[= cards([
     "commerce/payment/work_with_payments",
     "commerce/payment/work_with_payment_methods"
-], columns=3) =]] 
+], columns=3, force_version="4.5") =]] 

--- a/docs/commerce/shipping_management/shipping_management.md
+++ b/docs/commerce/shipping_management/shipping_management.md
@@ -19,4 +19,4 @@ so that shipment processing is cancelled automatically when the customer cancels
 
 [[= cards([
     "commerce/shipping_management/work_with_shipping_methods"
-], columns=3) =]] 
+], columns=3, force_version="4.5") =]] 

--- a/docs/permission_management/permissions_and_users.md
+++ b/docs/permission_management/permissions_and_users.md
@@ -10,4 +10,4 @@ With the permission system of [[= product_name =]] you can control which users h
     "permission_management/permission_system",
     "permission_management/work_with_permissions",
     "user_management/manage_users",
-], columns=4) =]]
+], columns=4, force_version="4.5") =]]

--- a/docs/persona_paths/administrator.md
+++ b/docs/persona_paths/administrator.md
@@ -17,4 +17,4 @@ However, certain things can be done in the Back Office.
     "permission_management/permissions_and_users",
     "persona_paths/manage_content_model",
     "content_management/workflow_management/view_workflow_list"
-], columns=2) =]]
+], columns=2, force_version="4.5") =]]

--- a/docs/persona_paths/author_content.md
+++ b/docs/persona_paths/author_content.md
@@ -14,4 +14,4 @@ In [[= product_name =]] you store content data in Content items. Learn to add an
     "content_management/translate_content",
     "content_management/edit_images",
     "content_management/content_organization/copy_move_hide_content"
-], style="path") =]]
+], style="path", force_version="4.5") =]]

--- a/docs/persona_paths/editor.md
+++ b/docs/persona_paths/editor.md
@@ -25,4 +25,4 @@ Users who work as content editors can be tasked with the following responsibilit
     "content_management/taxonomy/work_with_tags",
     "persona_paths/publish_content",
     "persona_paths/organize_content"
-], style="path") =]]
+], style="path", force_version="4.5") =]]

--- a/docs/persona_paths/explorer.md
+++ b/docs/persona_paths/explorer.md
@@ -23,4 +23,4 @@ to browse a list of topics that bring you closer to understanding the product.
     "customer_management/customer_portal",
     "website_organization/multisite",
     "permission_management/permissions_and_users"
-]) =]]
+], force_version="4.5") =]]

--- a/docs/persona_paths/manage_content_model.md
+++ b/docs/persona_paths/manage_content_model.md
@@ -9,5 +9,5 @@ If you have Administrator permissions, you can develop a content model that is u
 [[= cards([
     "content_management/content_model",
     "content_management/create_edit_content_types"
-], style="path") =]]
+], style="path", force_version="4.5") =]]
 

--- a/docs/persona_paths/manage_products.md
+++ b/docs/persona_paths/manage_products.md
@@ -19,4 +19,4 @@ your stock and customers can easily browse your catalogs.
     "pim/manage_prices",
     "pim/manage_availability_and_stock",
     "pim/work_with_catalogs"
-], style="path") =]]
+], style="path", force_version="4.5") =]]

--- a/docs/persona_paths/organize_content.md
+++ b/docs/persona_paths/organize_content.md
@@ -10,4 +10,4 @@ In [[= product_name =]] you store content data in Content items. Learn to add an
     "content_management/content_organization/copy_move_hide_content",
     "content_management/content_organization/classify_content",
     "content_management/content_organization/manage_locations_urls",
-], columns=2) =]]
+], columns=2, force_version="4.5") =]]

--- a/docs/persona_paths/publish_content.md
+++ b/docs/persona_paths/publish_content.md
@@ -9,4 +9,4 @@ Once you are done editing the content, make it immediately accessible or schedul
 [[= cards([
     "content_management/publish_instantly",
     "content_management/schedule_publishing"
-], columns=2) =]] 
+], columns=2, force_version="4.5") =]] 

--- a/docs/persona_paths/shop_manager.md
+++ b/docs/persona_paths/shop_manager.md
@@ -27,4 +27,4 @@ including the following responsibilities:
     "commerce/payment/work_with_payment_methods",
     "commerce/order_management/work_with_orders",
     "commerce/payment/work_with_payments"
-], style="path") =]]
+], style="path", force_version="4.5") =]]

--- a/docs/personalization/configure_personalization.md
+++ b/docs/personalization/configure_personalization.md
@@ -26,4 +26,4 @@ To do this, navigate to one of the pages mentioned below and edit the item that 
     "personalization/scenarios",
     "personalization/content_types",
     "personalization/filters"
-]) =]]
+], force_version="4.5") =]]

--- a/docs/pim/pim.md
+++ b/docs/pim/pim.md
@@ -21,4 +21,4 @@ PIM's features are available from the left-hand menu.
     "pim/create_edit_product",
     "pim/work_with_catalogs",
     "pim/work_with_product_categories"
-], columns=3) =]] 
+], columns=3, force_version="4.5") =]] 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| JIRA Ticket   | <!-- URLs to GitHub or JIRA issue(s) (or N/A) -->
| Versions      | <!-- product version number, e.g.: 1.7, 1.13, 2.0 -->
| Edition       | <!-- Content/Headless, Experience, Commerce -->

`4.5`'s cards shouldn't have links leaving `4.5` for `latest`. Sometime the link is broken.

Example:
https://doc.ibexa.co/projects/userguide/en/4.5/persona_paths/author_content/ "Edit image"
In [persona_paths/author_content.md, content_management/edit_images/](https://github.com/ibexa/documentation-user/blob/4.5/docs/persona_paths/author_content.md?plain=1#L15) refers to [4.5 file](https://github.com/ibexa/documentation-user/blob/4.5/docs/content_management/edit_images.md) which doesn't exist on master or 4.6 (moved to [image_management/edit_images/](https://github.com/ibexa/documentation-user/blob/4.6/docs/image_management/edit_images.md)).

Forces `4.5`'s card links to stay on `4.5`.

### Pros:
- 4.5 links fixed in production
- 4.5 links fixed in ReadTheDocs PR preview
### Cons:
- Links are now broken locally (e.g. http://localhost/projects/userguide/en/4.5/content_management/edit_images doesn't work)

#### Checklist

- [ ] Text renders correctly
- [ ] Text has been checked with vale
- [ ] Description metadata is up to date
- [ ] Redirects cover removed/moved pages
- [ ] Added link to this PR in relevant JIRA ticket or code PR
